### PR TITLE
Bumped to version 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parallelmarkets",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "ParallelMarkets.com JavaScript SDK loading utility",
   "scripts": {
     "build": "cd packages/vanilla && pnpm build && cd ../react && pnpm build",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parallelmarkets/react",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "ParallelMarkets.com React SDK",
   "author": "Parallel Markets (https://parallelmarkets.com)",
   "license": "MIT",

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parallelmarkets/vanilla",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "ParallelMarkets.com JavaScript SDK loading utility",
   "author": "Parallel Markets (https://parallelmarkets.com)",
   "license": "MIT",


### PR DESCRIPTION
I accidentally pushed a change to `master` which fixes the `workspace` dependency in the React lib. This PR just bumps the version so that we can publish that update.