### PR TITLE
Add explicit support for React 18

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for v0.x
 
+## v0.0.7 (2022-11-01)
+
+### Enhancements
+
+  * Add explicit peer support for React ^18.0.0
+  * Remove test files from published package
+
 ## v0.0.6 (2022-10-31)
 
 ### Enhancements

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parallelmarkets/react",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "ParallelMarkets.com React SDK",
   "author": "Parallel Markets (https://parallelmarkets.com)",
   "license": "MIT",
@@ -40,8 +40,8 @@
   },
   "peerDependencies": {
     "@parallelmarkets/vanilla": "workspace:^",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 | ^17.0.0 | ^18.0.0",
+    "react-dom": "^16.8.0 | ^17.0.0 | ^18.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -56,7 +56,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src/*.jsx",
+    "src/*.svg"
   ],
   "keywords": [
     "ParallelMarkets"

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -30,7 +30,7 @@
   },
   "files": [
     "dist",
-    "src"
+    "src/*.js"
   ],
   "keywords": [
     "ParallelMarkets"


### PR DESCRIPTION
This PR fixes a warning shown when installing the package if you're using React 18:

```
└─┬ @parallelmarkets/react 0.0.6
  ├── ✕ unmet peer react@"^16.8.0 || ^17.0.0": found 18.2.0
  └── ✕ unmet peer react-dom@"^16.8.0 || ^17.0.0": found 18.2.0
```
