### PR TITLE
Fix unintentional function change in React package, release version 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parallelmarkets",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "ParallelMarkets.com JavaScript SDK loading utility",
   "scripts": {
     "build": "pnpm --filter '@parallelmarkets/*' build",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.1.1 (2024-05-02)
+
+### Fixed
+
+- A bug was fixed in our React package to ensure `getProfile` remains a function.
+
 ## v2.1.0 (2024-04-26)
 
 ### Changed

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- A bug was fixed in our React package to ensure `getProfile` remains a function.
+- A bug was fixed in our React package to ensure `getProfile` remains a function (#25)
 
 ## v2.1.0 (2024-04-26)
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parallelmarkets/react",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "ParallelMarkets.com React SDK",
   "author": "Parallel Markets (https://parallelmarkets.com)",
   "license": "MIT",

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -85,7 +85,7 @@ export const useParallel = () => {
     parallel,
     error,
     loginStatus,
-    getProfile: new Promise<ProfileApiResponse>(parallel.getProfile),
+    getProfile: () => new Promise<ProfileApiResponse>(parallel.getProfile),
     login: parallel.login,
     logout: parallel.logout,
   }

--- a/packages/vanilla/CHANGELOG.md
+++ b/packages/vanilla/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.1.1 (2024-05-02)
+
+### Fixed
+
+- A bug was fixed in our React package to ensure `getProfile` remains a function.
+
 ## v2.1.0 (2024-04-26)
 
 ### Changed

--- a/packages/vanilla/CHANGELOG.md
+++ b/packages/vanilla/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- A bug was fixed in our React package to ensure `getProfile` remains a function.
+- A bug was fixed in our React package to ensure `getProfile` remains a function (#25)
 
 ## v2.1.0 (2024-04-26)
 

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parallelmarkets/vanilla",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "ParallelMarkets.com JavaScript SDK loading utility",
   "author": "Parallel Markets (https://parallelmarkets.com)",
   "license": "MIT",


### PR DESCRIPTION
This PR fixes a bug where `getProfile` in the React package was not defined as a function any more.